### PR TITLE
Add Annual Impact Report 2025-2026 link to about page

### DIFF
--- a/api/local.settings.json.example
+++ b/api/local.settings.json.example
@@ -6,7 +6,7 @@
     "EMAIL_SMTP_HOST": "smtp.gmail.com",
     "EMAIL_SMTP_PORT": "587",
     "EMAIL_SMTP_SECURE": "false",
-    "EMAIL_SMTP_USERNAME": "empathysoupkitchen@gmail.com",
+    "EMAIL_SMTP_USERNAME": "leadership@empathysoupkitchen.org",
     "EMAIL_SMTP_PASSWORD": "your-app-specific-password-here",
     "EMAIL_SENDER_NAME": "Empathy Soup Kitchen",
     "EMAIL_SENDER_EMAIL": "noreply@empathysoupkitchen.org",

--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -10,6 +10,24 @@
   </div>
 </section>
 
+<!-- Annual Impact Report -->
+<section class="report section--cream section">
+  <div class="container">
+    <div class="report__content" appScrollAnimate>
+      <span class="section-label">Transparency</span>
+      <h2 class="section-title">Annual Impact Report 2025&ndash;2026</h2>
+      <p>
+        See how your support has made a difference. Our annual report covers
+        financials, community impact, and our plans for the future.
+      </p>
+      <a href="https://eskupdates.pages.dev/" target="_blank" rel="noopener noreferrer" class="report__link">
+        <span class="material-icons">description</span>
+        View the Full Report
+      </a>
+    </div>
+  </div>
+</section>
+
 <!-- Board Members -->
 <section class="board section--cream section">
   <div class="container">
@@ -92,7 +110,7 @@
           <div class="contact__detail">
             <span class="material-icons">email</span>
             <div>
-              <a href="mailto:empathysoupkitchen&#64;gmail.com">empathysoupkitchen&#64;gmail.com</a>
+              <a href="mailto:leadership&#64;empathysoupkitchen.org">leadership&#64;empathysoupkitchen.org</a>
             </div>
           </div>
         </div>

--- a/src/app/pages/about/about.component.scss
+++ b/src/app/pages/about/about.component.scss
@@ -22,6 +22,42 @@
   position: relative;
 }
 
+/* Report */
+.report__content {
+  max-width: 600px;
+  margin: 0 auto;
+  text-align: center;
+
+  p {
+    color: var(--color-text-secondary);
+    line-height: 1.7;
+    margin-top: var(--space-lg);
+  }
+}
+
+.report__link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-xl);
+  padding: var(--space-md) var(--space-xl);
+  background: var(--color-terracotta);
+  color: #fff;
+  font-weight: 600;
+  font-size: var(--font-size-base);
+  border-radius: var(--border-radius-md);
+  text-decoration: none;
+  transition: background var(--transition-base);
+
+  .material-icons {
+    font-size: 20px;
+  }
+
+  &:hover {
+    background: var(--color-charcoal);
+  }
+}
+
 /* Board */
 .board__header {
   text-align: center;


### PR DESCRIPTION
## Summary
- Adds a new "Annual Impact Report 2025–2026" section to the about page (between Mission and Board Members) linking to https://eskupdates.pages.dev/
- Updates contact email from gmail to leadership@empathysoupkitchen.org

## Test plan
- [ ] Verify the report section renders correctly on the about page
- [ ] Confirm the "View the Full Report" button opens the report in a new tab
- [ ] Check the updated contact email displays and links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)